### PR TITLE
Step12

### DIFF
--- a/src/main/kotlin/io/hhplus/concertreservationservice/domain/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/io/hhplus/concertreservationservice/domain/reservation/service/ReservationService.kt
@@ -15,8 +15,8 @@ import io.hhplus.concertreservationservice.domain.reservation.SeatReservation
 import io.hhplus.concertreservationservice.domain.reservation.exception.AlreadyReservedException
 import io.hhplus.concertreservationservice.domain.reservation.extension.toCreateReservedSeatInfo
 import io.hhplus.concertreservationservice.domain.reservation.repository.SeatReservationRepository
+import io.hhplus.concertreservationservice.infrastructure.lock.DistributedLock
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ReservationService(
@@ -52,7 +52,8 @@ class ReservationService(
         reservationRepository.saveReservation(reservation)
     }
 
-    @Transactional
+//        @Transactional
+    @DistributedLock(key = "#command.concertId + ':' + #command.scheduleId + ':' + #command.seatNo")
     fun createReservationInfo(command: CreateReserveSeatCommand): CreateReservedSeatInfo {
         // 좌석 예약 유무 확인
         val reservedSeat =

--- a/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/config/RedissonConfig.kt
+++ b/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/config/RedissonConfig.kt
@@ -1,0 +1,31 @@
+package io.hhplus.concertreservationservice.infrastructure.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonConfig(
+    @Value("\${spring.data.redis.host}") private val redisHost: String,
+    @Value("\${spring.data.redis.port}") private val redisPort: Int,
+) {
+    companion object {
+        const val REDISSON_HOST_PREFIX = "redis://"
+        const val DEFAULT_POOL_SIZE = 10
+        const val MINIMUM_IDLE_SIZE = 2
+    }
+
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val config = Config()
+        config.useSingleServer().apply {
+            address = "${REDISSON_HOST_PREFIX}$redisHost:$redisPort"
+            connectionPoolSize = DEFAULT_POOL_SIZE
+            connectionMinimumIdleSize = MINIMUM_IDLE_SIZE
+        }
+        return Redisson.create(config)
+    }
+}

--- a/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/AopForTransaction.kt
+++ b/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/AopForTransaction.kt
@@ -1,0 +1,15 @@
+package io.hhplus.concertreservationservice.infrastructure.lock
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class AopForTransaction {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Throws(Throwable::class)
+    fun proceed(joinPoint: ProceedingJoinPoint): Any? {
+        return joinPoint.proceed()
+    }
+}

--- a/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/CustomSpringELParser.kt
+++ b/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/CustomSpringELParser.kt
@@ -1,0 +1,24 @@
+package io.hhplus.concertreservationservice.infrastructure.lock
+
+import org.springframework.expression.ExpressionParser
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+
+class CustomSpringELParser private constructor() {
+    companion object {
+        fun getDynamicValue(
+            parameterNames: Array<String>,
+            args: Array<Any>,
+            key: String,
+        ): Any? {
+            val parser: ExpressionParser = SpelExpressionParser()
+            val context = StandardEvaluationContext()
+
+            parameterNames.forEachIndexed { index, paramName ->
+                context.setVariable(paramName, args[index])
+            }
+
+            return parser.parseExpression(key).getValue(context, Any::class.java)
+        }
+    }
+}

--- a/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/DistributedLock.kt
+++ b/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/DistributedLock.kt
@@ -1,0 +1,26 @@
+package io.hhplus.concertreservationservice.infrastructure.lock
+
+import java.util.concurrent.TimeUnit
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DistributedLock(
+    /**
+     * 락의 이름
+     */
+    val key: String,
+    /**
+     * 락의 시간 단위
+     */
+    val timeUnit: TimeUnit = TimeUnit.SECONDS,
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    val waitTime: Long = 5L,
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    val leaseTime: Long = 3L,
+)

--- a/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/DistributedLockAop.kt
+++ b/src/main/kotlin/io/hhplus/concertreservationservice/infrastructure/lock/DistributedLockAop.kt
@@ -1,0 +1,68 @@
+package io.hhplus.concertreservationservice.infrastructure.lock
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class DistributedLockAop(
+    private val redissonClient: RedissonClient,
+    private val aopForTransaction: AopForTransaction,
+) {
+    companion object {
+        private const val REDISSON_LOCK_PREFIX = "LOCK:"
+        private val log: Logger = LoggerFactory.getLogger(DistributedLockAop::class.java)
+    }
+
+    @Around("@annotation(io.hhplus.concertreservationservice.infrastructure.lock.DistributedLock)")
+    @Throws(Throwable::class)
+    fun lock(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val distributedLock = method.getAnnotation(DistributedLock::class.java)
+
+        val key =
+            REDISSON_LOCK_PREFIX +
+                CustomSpringELParser.getDynamicValue(
+                    signature.parameterNames,
+                    joinPoint.args,
+                    distributedLock.key,
+                )
+        val rLock: RLock = redissonClient.getLock(key)
+
+        return try {
+            val available =
+                rLock.tryLock(
+                    distributedLock.waitTime,
+                    distributedLock.leaseTime,
+                    distributedLock.timeUnit,
+                )
+            if (!available) {
+                return false
+            }
+
+            aopForTransaction.proceed(joinPoint)
+        } catch (e: InterruptedException) {
+            throw InterruptedException()
+        } finally {
+            try {
+                if (rLock.isHeldByCurrentThread) {
+                    rLock.unlock()
+                }
+            } catch (e: IllegalMonitorStateException) {
+                log.info(
+                    "Redisson Lock Already Unlocked: serviceName = {}, key = {}",
+                    method.name,
+                    key,
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/hhplus/concertreservationservice/domain/concert/service/ReservationConcurrencyServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/concertreservationservice/domain/concert/service/ReservationConcurrencyServiceTest.kt
@@ -125,5 +125,89 @@ class ReservationConcurrencyServiceTest(
                     successfulApplications.get() shouldBe 1
                 }
             }
+
+            `when`("50개 스레드가 동시에 예약을 시도하면") {
+                val threadCount = 50
+                val latch = CountDownLatch(threadCount)
+                val executor: ExecutorService = Executors.newFixedThreadPool(threadCount)
+                val successfulApplications = AtomicInteger(0)
+                val failApplications = AtomicInteger(0)
+
+                for (i in 1..threadCount) {
+                    executor.submit {
+                        try {
+                            reservationService.createReservationInfo(command)
+                            successfulApplications.incrementAndGet()
+                        } catch (e: Exception) {
+                            failApplications.incrementAndGet()
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+                executor.shutdown()
+
+                then("예약이 한 번만 완료되어야 한다") {
+                    successfulApplications.get() shouldBe 1
+                }
+            }
+
+            `when`("1000개 스레드가 동시에 예약을 시도하면") {
+                val threadCount = 1000
+                val latch = CountDownLatch(threadCount)
+                val executor: ExecutorService = Executors.newFixedThreadPool(threadCount)
+                val successfulApplications = AtomicInteger(0)
+                val failApplications = AtomicInteger(0)
+
+                for (i in 1..threadCount) {
+                    executor.submit {
+                        try {
+                            reservationService.createReservationInfo(command)
+                            successfulApplications.incrementAndGet()
+                        } catch (e: Exception) {
+                            failApplications.incrementAndGet()
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+                executor.shutdown()
+
+                then("예약이 한 번만 완료되어야 한다") {
+                    successfulApplications.get() shouldBe 1
+                }
+            }
+
+            `when`("3000개 스레드가 동시에 예약을 시도하면") {
+                val threadCount = 3000
+                val latch = CountDownLatch(threadCount)
+                val executor: ExecutorService = Executors.newFixedThreadPool(threadCount)
+                val successfulApplications = AtomicInteger(0)
+                val failApplications = AtomicInteger(0)
+
+                for (i in 1..threadCount) {
+                    executor.submit {
+                        try {
+                            reservationService.createReservationInfo(command)
+                            successfulApplications.incrementAndGet()
+                        } catch (e: Exception) {
+                            failApplications.incrementAndGet()
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+                executor.shutdown()
+
+                then("예약이 한 번만 완료되어야 한다") {
+                    successfulApplications.get() shouldBe 1
+                }
+            }
         }
     })


### PR DESCRIPTION
### **커밋 링크**
1. redisson config 추가 : 8d8b1cb709bdc619b2aa660364739c712a4190dd
2. AOP를 활용한 분산락 기능 추가 : 8ee105196c5cbb15a2f3d74d3016ccc6597e3637
3. 좌석 예약 usecase에 분산락 및 테스트 코드 추가 : 482e0711621ba9e41adfc48c8a7b019acd74efea

### 락 구현 방식
**성능비교와 각 usecase별 락 적용 은 #49 에 작성되어있습니다.**
1. 좌석예약 : 분산락 + 비관적락
2. 충전 : 비관적락

### 락 구현 코드
1. 좌석 예약 : 분산락 구현 - 8ee105196c5cbb15a2f3d74d3016ccc6597e3637, 분산락 적용 - 482e0711621ba9e41adfc48c8a7b019acd74efea
3. 충전 : [코드](https://github.com/hhplus-backend/concert-reservation-service/blob/main/src/main/kotlin/io/hhplus/concertreservationservice/domain/balance/service/BalanceService.kt)

### 통합테스트
1. 좌석예약 : [코드](https://github.com/hhplus-backend/concert-reservation-service/blob/main/src/test/kotlin/io/hhplus/concertreservationservice/domain/concert/service/ReservationConcurrencyServiceTest.kt), [추가된 코드](482e0711621ba9e41adfc48c8a7b019acd74efea)
3. 충전 : [코드](https://github.com/hhplus-backend/concert-reservation-service/blob/main/src/test/kotlin/io/hhplus/concertreservationservice/domain/balance/service/BalanceServiceConcurrencyTest.kt)

### e2e 테스트
1. 좌석 예약 : [코드](https://github.com/hhplus-backend/concert-reservation-service/blob/main/src/test/kotlin/io/hhplus/concertreservationservice/presentation/controller/concert/ConcertReservationIntegrationControllerTest.kt)
2. 충전 : [코드](https://github.com/hhplus-backend/concert-reservation-service/blob/main/src/test/kotlin/io/hhplus/concertreservationservice/presentation/controller/balance/BalanceIntegrationControllerTest.kt)


---
### **리뷰 포인트(질문)**
- 기본적으로 이런 성능에 대한? 보고서는 어떤 흐름을 가지고 있는지가 궁금합니다. 또한 제출한 보고서에 추가되면 좋을 것 같은 내용이 궁금합니다.


---
### Keep
꾸준히 하는 노력

### Problem
천천히 시간에 쫓기지 않고 하기

### Try
최대한 이것저것 예외 케이스 생각해보기
